### PR TITLE
Correct a broken image directive

### DIFF
--- a/api-docs/concepts.rst
+++ b/api-docs/concepts.rst
@@ -181,7 +181,8 @@ member of the image, the consumer can use the image, regardless of the
 image member status.
 
 .. image:: /_images/image-member.png
-            Sharing an image
+   :alt: Sharing an image
+
 .. note::
    In the Cloud Images API, the image member status serves three
    purposes:


### PR DESCRIPTION
The build for this repository has been broken in Strider due to a malformed `.. image::` directive:

```
./concepts.rst:184: WARNING: image file not readable: _images/image-member.pngSharinganimage
# ...
FileNotFoundError: [Errno 2] No such file or directory: '/workspace/data/rackerlabs-docs-cloud-images-master/job-57238fa08f1e240100c19acc/api-docs/_images/image-member.pngSharinganimage'
Oh no: [Error: Preparer exitted with an error status 1]
```

I've touched up the .rst to [specify the alt text correctly.](http://docutils.sourceforge.net/docs/ref/rst/directives.html#image)